### PR TITLE
Point default VIDEO_URL at the freshly-transcoded 1080p asset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM --platform=$BUILDPLATFORM alpine:3.20 AS video
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl
 
-ARG VIDEO_URL=https://github.com/modem7/docker-rickroll/releases/download/video-assets-v1/video.mp4
+ARG VIDEO_URL=https://github.com/modem7/docker-rickroll/releases/download/video-assets-v1/video-1080p.mp4
 
 WORKDIR /video
 RUN curl -fsSL "$VIDEO_URL" -o video.mp4

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The video is fetched pre-transcoded from a video asset attached to a [GitHub Rel
 
 | Build Arg | Description | Default |
 | :----: | --- | --- |
-| VIDEO_URL | URL the build downloads the (already-transcoded) video from. | [video-assets-v1/video.mp4](https://github.com/modem7/docker-rickroll/releases/download/video-assets-v1/video.mp4) (1080p) |
+| VIDEO_URL | URL the build downloads the (already-transcoded) video from. | [video-assets-v1/video-1080p.mp4](https://github.com/modem7/docker-rickroll/releases/download/video-assets-v1/video-1080p.mp4) |
 
 ```bash
 # build the default (1080p, matches the published `latest` tag)


### PR DESCRIPTION
## Summary
- Default `VIDEO_URL` build arg now points at `video-1080p.mp4` (224MB, generated by the `video-assets.yml` transcode workflow) instead of the old interim `video.mp4` (29MB, predates the transcode pipeline)
- All four published tags (480p/720p/latest-1080p/2160p) now come from the same consistent `-crf 18` ffmpeg transcode of the 4K master, rather than 3 of them using the new pipeline and `latest`/`1080p` quietly using an older, lower-quality asset
- Still fully overridable via `--build-arg VIDEO_URL=...`

## Test plan
- [x] Verified the new asset URL resolves (200) before pointing the default at it
- [ ] CI (`test.yml`) build/env-var/autoplay checks pass on this PR