### PR TITLE
Fix video pausing instead of unmuting on mousemove

### DIFF
--- a/.github/scripts/test-autoplay.js
+++ b/.github/scripts/test-autoplay.js
@@ -35,14 +35,18 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
     throw new Error(`expected initial title "Loading...", got "${initial.title}"`);
   }
 
-  await page.mouse.move(100, 100);
+  // mousemove/wheel don't count as "user interaction" for Chrome's
+  // autoplay policy - unmuting off one of those gets treated as an
+  // unmute without interaction and the browser pauses the video instead,
+  // so this test deliberately uses a real click, not a mouse move.
+  await page.mouse.click(100, 100);
 
   const unmuted = await waitFor(page, () => {
     const v = document.querySelector('video');
     return !!v && !v.muted;
   });
   if (!unmuted) {
-    throw new Error('expected video to unmute after mouse movement within 5s, but it is still muted');
+    throw new Error('expected video to unmute after a click within 5s, but it is still muted');
   }
 
   const after = await page.evaluate(() => {

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Image is based on nginxinc/nginx-unprivileged, runs as a non-root user, and ever
 
 # How it works
 
-- The page autoplays the video muted (every browser allows this), then unmutes itself on the first interaction - a click, a keypress, even just moving the mouse. In practice, sound kicks in within a fraction of a second, with no visible prompt.
+- The page autoplays the video muted (every browser allows this), then unmutes itself on the first genuine interaction - a click, a tap, a keypress. Sound kicks in almost immediately, with no visible prompt. (Mouse movement/scrolling deliberately isn't used to trigger this - browsers don't count those as real interaction, and unmuting off one just gets the video paused by the browser's autoplay enforcement instead.)
 - The video is served through nginx's mp4 module, so seeking/scrubbing and byte-range requests work properly and responses are cached.
 - The video isn't stored in git. It's fetched from a GitHub Release asset at build time and baked into the image, so the shipped container is still fully self-contained and works offline - git just doesn't carry the binary around.
 - Built for both linux/amd64 and linux/arm64/v8.

--- a/scripts/index/80-index.sh
+++ b/scripts/index/80-index.sh
@@ -77,7 +77,12 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
         (function () {
             var video = document.getElementById('video');
             var title = "$TITLE";
-            var events = ['click', 'keydown', 'touchstart', 'pointerdown', 'mousemove', 'wheel'];
+            // Only events Chrome/Vivaldi/etc actually count as "user
+            // interaction" for autoplay purposes. mousemove/wheel don't
+            // qualify - unmuting off one of those gets treated as an
+            // unmute without interaction, and the browser pauses the
+            // video as enforcement rather than actually unmuting it.
+            var events = ['click', 'keydown', 'touchstart', 'pointerdown'];
 
             function reveal() {
                 video.muted = false;


### PR DESCRIPTION
## Summary
- Bug: video autoplays muted correctly, but moving the mouse over it (reported in Vivaldi) pauses the video instead of unmuting it
- Root cause: `mousemove`/`wheel` don't count as "user interaction" for Chrome's autoplay policy - per Chrome's own docs, unmuting a playing video without qualifying interaction causes the browser to pause it as enforcement, rather than actually unmuting it
- Fix: only trigger the unmute on `click`/`keydown`/`touchstart`/`pointerdown` - the events that actually count as real interaction
- Also fixes the CI autoplay test, which was using `page.mouse.move()` to trigger unmute (masking this exact bug) - switched to a real click

## Test plan
- [x] Reproduced: dispatching a raw `mousemove` (no click) fired the reveal handler before this fix
- [x] Verified after the fix: `mousemove` alone leaves the video muted/`Loading...` untouched; a real click still correctly unmutes + plays + updates the title
- [ ] CI (`test.yml`) passes with the updated Playwright test