### PR TITLE
Fix redirect leaking nginx's internal port behind a reverse proxy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,14 +50,27 @@ jobs:
           set -eu
           headers=$(curl -sS -o /dev/null -D - http://localhost:8080/)
           echo "$headers" | grep -qE '^HTTP/[0-9.]+ 302'
-          echo "$headers" | grep -qiE '^location:.*/video\.mp4'
+          echo "$headers" | grep -qiE '^location: *http://localhost:8080/video\.mp4'
 
       - name: Check an arbitrary path also redirects to the video
         run: |
           set -eu
           headers=$(curl -sS -o /dev/null -D - http://localhost:8080/some/random/path)
           echo "$headers" | grep -qE '^HTTP/[0-9.]+ 302'
-          echo "$headers" | grep -qiE '^location:.*/video\.mp4'
+          echo "$headers" | grep -qiE '^location: *http://localhost:8080/video\.mp4'
+
+      - name: Check redirect doesn't leak nginx's own port behind a reverse proxy
+        run: |
+          set -eu
+          # Simulates Traefik/nginx-proxy terminating TLS on 443 and forwarding
+          # to this container's internal port - the Location header must
+          # reflect the client-facing host/scheme, not nginx's own listen port.
+          headers=$(curl -sS -o /dev/null -D - \
+            -H "Host: rickroll.example.com" \
+            -H "X-Forwarded-Proto: https" \
+            http://localhost:8080/)
+          echo "$headers" | grep -qE '^HTTP/[0-9.]+ 302'
+          echo "$headers" | grep -qiE '^location: *https://rickroll\.example\.com/video\.mp4'
 
       - name: Check video file is actually served
         run: |

--- a/scripts/70-nginx.sh
+++ b/scripts/70-nginx.sh
@@ -37,6 +37,18 @@ http {
     gzip_vary on;
     gzip_http_version 1.1;
 
+    # Redirects must reflect what the client actually connected to, not
+    # nginx's own internal scheme/port - otherwise a reverse proxy that
+    # terminates TLS on 443 and forwards to some other internal port (e.g.
+    # Traefik) ends up with that internal port leaking into the Location
+    # header. Trust X-Forwarded-Proto when a proxy sets it, otherwise fall
+    # back to nginx's own scheme for direct (non-proxied) access.
+    map $http_x_forwarded_proto $redirect_scheme {
+        default $scheme;
+        https   https;
+        http    http;
+    }
+
     server {
         listen       ${PORT} default_server;
 
@@ -62,7 +74,7 @@ http {
         }
 
         location / {
-            return 302 /video.mp4;
+            return 302 $redirect_scheme://$http_host/video.mp4;
         }
     }
 }


### PR DESCRIPTION
## Summary
Reported: deploying behind Traefik (TLS terminated on 443 externally, forwarded to the container's internal `PORT=1987`), the redirect became `https://domain:1987/video.mp4` instead of `https://domain/video.mp4`.

`return 302 /video.mp4;` makes nginx build a fully-qualified URL using its own scheme and `$server_port` - it has zero awareness that a reverse proxy is translating ports in front of it. Fixed by building the redirect from what the client actually sent instead:
- `$http_host` (Traefik forwards this unchanged, and it never includes a port for default-port HTTPS)
- a `$redirect_scheme` map that trusts `X-Forwarded-Proto` when a proxy sets it, falling back to nginx's own `$scheme` for direct, non-proxied access

## Test plan
- [x] Added a regression test simulating the exact reverse-proxy scenario (custom Host + `X-Forwarded-Proto: https`) - expects no port leaked into the Location header
- [x] Strengthened the existing direct-access redirect tests to check the exact expected URL, not just that it contains `/video.mp4`
- [ ] CI (`test.yml`) passes