### PR TITLE
Add GHCR publishing, docker run quick-start, and GitHub topics

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,0 +1,57 @@
+name: Publish to GHCR
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - resolution: 480p
+            video_url: https://github.com/modem7/docker-rickroll/releases/download/video-assets-v1/video-480p.mp4
+            tags: ghcr.io/${{ github.repository }}:480p
+          - resolution: 720p
+            video_url: https://github.com/modem7/docker-rickroll/releases/download/video-assets-v1/video-720p.mp4
+            tags: ghcr.io/${{ github.repository }}:720p
+          - resolution: 1080p
+            video_url: ""
+            tags: |
+              ghcr.io/${{ github.repository }}:latest
+              ghcr.io/${{ github.repository }}:1080p
+          - resolution: 2160p
+            video_url: https://github.com/modem7/docker-rickroll/releases/download/video-assets-v1/video-2160p.mp4
+            tags: ghcr.io/${{ github.repository }}:2160p
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.resolution }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64/v8
+          build-args: |
+            ${{ matrix.video_url != '' && format('VIDEO_URL={0}', matrix.video_url) || '' }}
+          tags: ${{ matrix.tags }}

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -55,3 +55,10 @@ jobs:
           build-args: |
             ${{ matrix.video_url != '' && format('VIDEO_URL={0}', matrix.video_url) || '' }}
           tags: ${{ matrix.tags }}
+          # Scoped per resolution so the four matrix legs (different
+          # VIDEO_URL/content each) don't stomp on each other's cache.
+          # mode=max also caches the video-fetch stage, not just the
+          # final image, so re-runs skip re-downloading the video
+          # asset entirely when VIDEO_URL hasn't changed.
+          cache-from: type=gha,scope=${{ matrix.resolution }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.resolution }}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ This is a self-hosted Rickroll container. Point someone at it - a link, a QR cod
 
 Image is based on nginxinc/nginx-unprivileged, runs as a non-root user, and everything needed to serve the video is baked into the image at build time - no external dependencies at runtime.
 
+# Quick start
+
+```bash
+docker run -d -p 8080:8080 --name rickroll modem7/docker-rickroll
+```
+
+Then visit `http://localhost:8080` - see the [Configuration example](#configuration-example) below for a docker-compose version.
+
+Also published to GHCR if you'd rather pull from there: `ghcr.io/modem7/docker-rickroll`.
+
 # How it works
 
 - Every request gets sent straight to the raw video file instead of an HTML page with a `<video>` tag embedded in it. Browsers gate unmuted autoplay on an embedded `<video>` element behind a genuine user gesture (a click/tap/keypress) - but a directly-navigated media file goes through the browser's own native media-document viewer instead, which autoplays with sound with zero interaction required. That's the whole trick, and why there's no "click to unmute" moment.


### PR DESCRIPTION
## Summary
Part of improving discoverability (repo currently has 202k Docker pulls but only 5 GitHub stars - awareness gap, not usage gap):

- **GHCR publishing**: new manually-triggered workflow (`ghcr-publish.yml`) publishes all four resolution tags to `ghcr.io/modem7/docker-rickroll` alongside Docker Hub. Uses GH Actions' own `GITHUB_TOKEN` (auto-scoped to this repo's packages) rather than a manually-managed PAT, so there's nothing new to store as a secret.
- **Quick start**: added a copy-paste `docker run` one-liner ahead of the compose example, for people who don't want to write a compose file just to try it.
- **GitHub topics**: expanded from `docker`/`docker-container`/`linux`/`rickroll` to also include `nginx`, `self-hosted`, `homelab`, `prank`, `meme`, `video`, `docker-image` (already applied directly via the API, not part of this diff).

## Heads up
The first push to a brand-new GHCR package typically defaults to **private** visibility even though this repo is public - after this workflow runs for the first time, someone with admin on the repo needs to flip it to public in the package's own settings page (Settings not exposed via API in a way I could do it as part of the push).

## Test plan
- [ ] CI (`test.yml`) passes (this PR doesn't touch the Dockerfile/scripts, so it may not even trigger)
- [ ] Manually run `ghcr-publish.yml` once merged and confirm all 4 tags land on GHCR
- [ ] Flip the new GHCR package to public visibility