### PR TITLE
Revert to muted autoplay + clickbait overlay (real autoplay is impossible)

### DIFF
--- a/.github/scripts/test-autoplay.js
+++ b/.github/scripts/test-autoplay.js
@@ -1,12 +1,16 @@
 const { chromium } = require('playwright');
 
-const overlayType = process.argv[2];
-if (overlayType !== 'cookie' && overlayType !== 'error') {
-  throw new Error(`usage: node test-autoplay.js <cookie|error>, got "${overlayType}"`);
-}
+const CONFIG = {
+  cookie: { overlaySelector: '#cookie-banner', clickSelector: '#cookie-banner button' },
+  error: { overlaySelector: '#site-error', clickSelector: '#site-error button' },
+  loading: { overlaySelector: '#loading-screen', clickSelector: 'body' }
+};
 
-const overlaySelector = overlayType === 'cookie' ? '#cookie-banner' : '#site-error';
-const buttonSelector = `${overlaySelector} button`;
+const overlayType = process.argv[2];
+if (!CONFIG[overlayType]) {
+  throw new Error(`usage: node test-autoplay.js <${Object.keys(CONFIG).join('|')}>, got "${overlayType}"`);
+}
+const { overlaySelector, clickSelector } = CONFIG[overlayType];
 
 async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {}) {
   const start = Date.now();
@@ -52,14 +56,14 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
     throw new Error(`expected the ${overlayType} overlay to be visible, but it wasn't`);
   }
 
-  await page.click(buttonSelector);
+  await page.click(clickSelector);
 
   const unmuted = await waitFor(page, () => {
     const v = document.getElementById('video');
     return !!v && !v.muted;
   });
   if (!unmuted) {
-    throw new Error('expected video to unmute after clicking the overlay button within 5s, but it is still muted');
+    throw new Error('expected video to unmute after clicking within 5s, but it is still muted');
   }
 
   const after = await page.evaluate((sel) => {
@@ -79,10 +83,10 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
     throw new Error(`expected title "Rickroll" after interaction, got "${after.title}"`);
   }
   if (after.overlayVisible) {
-    throw new Error(`expected the ${overlayType} overlay to be hidden after clicking it, but it is still visible`);
+    throw new Error(`expected the ${overlayType} overlay to be hidden after clicking, but it is still visible`);
   }
 
-  console.log(`OK: ${overlayType} overlay shown, video autoplays muted, and clicking it unmutes + hides the overlay`);
+  console.log(`OK: ${overlayType} overlay shown, video autoplays muted, and clicking unmutes + hides the overlay`);
   await browser.close();
 })().catch((err) => {
   console.error(err);

--- a/.github/scripts/test-autoplay.js
+++ b/.github/scripts/test-autoplay.js
@@ -1,5 +1,13 @@
 const { chromium } = require('playwright');
 
+const overlayType = process.argv[2];
+if (overlayType !== 'cookie' && overlayType !== 'error') {
+  throw new Error(`usage: node test-autoplay.js <cookie|error>, got "${overlayType}"`);
+}
+
+const overlaySelector = overlayType === 'cookie' ? '#cookie-banner' : '#site-error';
+const buttonSelector = `${overlaySelector} button`;
+
 async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {}) {
   const start = Date.now();
   while (Date.now() - start < timeout) {
@@ -14,32 +22,67 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
   const page = await browser.newPage();
   await page.goto('http://localhost:8080/', { waitUntil: 'load' });
 
-  if (!page.url().endsWith('/video.mp4')) {
-    throw new Error(`expected to be redirected straight to /video.mp4, ended up at ${page.url()}`);
-  }
-
   // Autoplay isn't instantaneous - the browser needs a moment to buffer
   // before playback actually begins, so poll rather than checking once.
   const startedPlaying = await waitFor(page, () => {
-    const v = document.querySelector('video');
+    const v = document.getElementById('video');
     return !!v && !v.paused;
   });
   if (!startedPlaying) {
-    throw new Error('expected video to start playing within 5s, but it never left the paused state');
+    throw new Error('expected video to start autoplaying (muted) within 5s, but it never left the paused state');
   }
 
-  const state = await page.evaluate(() => {
-    const v = document.querySelector('video');
-    return { muted: v.muted, paused: v.paused };
+  const initial = await page.evaluate((sel) => {
+    const v = document.getElementById('video');
+    const overlay = document.querySelector(sel);
+    return {
+      muted: v.muted,
+      title: document.title,
+      overlayVisible: overlay ? !overlay.classList.contains('hidden') : null
+    };
+  }, overlaySelector);
+
+  if (!initial.muted) {
+    throw new Error(`expected video to start muted, got muted=${initial.muted}`);
+  }
+  if (initial.title !== 'Loading...') {
+    throw new Error(`expected initial title "Loading...", got "${initial.title}"`);
+  }
+  if (!initial.overlayVisible) {
+    throw new Error(`expected the ${overlayType} overlay to be visible, but it wasn't`);
+  }
+
+  await page.click(buttonSelector);
+
+  const unmuted = await waitFor(page, () => {
+    const v = document.getElementById('video');
+    return !!v && !v.muted;
   });
-  if (state.muted) {
-    throw new Error('expected the video to be playing WITH sound with zero interaction, but it is muted');
-  }
-  if (state.paused) {
-    throw new Error('expected the video to still be playing');
+  if (!unmuted) {
+    throw new Error('expected video to unmute after clicking the overlay button within 5s, but it is still muted');
   }
 
-  console.log('OK: video autoplays with sound immediately, no interaction required');
+  const after = await page.evaluate((sel) => {
+    const v = document.getElementById('video');
+    const overlay = document.querySelector(sel);
+    return {
+      paused: v.paused,
+      title: document.title,
+      overlayVisible: overlay ? !overlay.classList.contains('hidden') : null
+    };
+  }, overlaySelector);
+
+  if (after.paused) {
+    throw new Error('expected video to still be playing after unmuting');
+  }
+  if (after.title !== 'Rickroll') {
+    throw new Error(`expected title "Rickroll" after interaction, got "${after.title}"`);
+  }
+  if (after.overlayVisible) {
+    throw new Error(`expected the ${overlayType} overlay to be hidden after clicking it, but it is still visible`);
+  }
+
+  console.log(`OK: ${overlayType} overlay shown, video autoplays muted, and clicking it unmutes + hides the overlay`);
   await browser.close();
 })().catch((err) => {
   console.error(err);

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
           echo "$html" | grep -q 'source src="video.mp4"'
           echo "$html" | grep -q 'id="cookie-banner"'
           echo "$html" | grep -q 'id="site-error"'
+          echo "$html" | grep -q 'id="loading-screen"'
 
       - name: Check video file is actually served
         run: |
@@ -106,6 +107,49 @@ jobs:
       - name: Stop custom PORT container
         run: docker rm -f rickroll-port
 
+      - name: Start container with custom env vars
+        run: |
+          docker run -d --name rickroll-custom -p 8080:8080 \
+            -e TITLE="Custom Title" \
+            -e PRE_TITLE="Custom Loading" \
+            -e HEADLINE="Never Gonna Give You Up" \
+            -e HEIGHT=50vh \
+            -e WIDTH=50% \
+            -e OBJECT_FIT=contain \
+            -e LOOP=false \
+            -e VIDEO_FILE=custom.mp4 \
+            -e OVERLAY=cookie,loading \
+            rickroll:test
+
+      - name: Wait for custom container to be healthy
+        run: |
+          for i in $(seq 1 30); do
+            docker exec rickroll-custom curl -fsS http://localhost:9090/healthz && exit 0
+            sleep 1
+          done
+          docker logs rickroll-custom
+          exit 1
+
+      - name: Check custom env vars took effect
+        run: |
+          set -eu
+          html=$(curl -fsS http://localhost:8080/)
+          echo "$html" | grep -q '<title>Custom Loading</title>'
+          echo "$html" | grep -q 'var title = "Custom Title";'
+          echo "$html" | grep -q 'id="headline" class="hidden">Never Gonna Give You Up<'
+          echo "$html" | grep -q 'height: 50vh'
+          echo "$html" | grep -q 'width: 50%'
+          echo "$html" | grep -q 'object-fit: contain'
+          echo "$html" | grep -q 'source src="custom.mp4"'
+          if echo "$html" | grep -qE '<video id="video"[^>]*\bloop\b'; then
+            echo "unexpected loop attribute present with LOOP=false"
+            exit 1
+          fi
+          echo "$html" | grep -q '"cookie,loading".split'
+
+      - name: Stop custom container
+        run: docker rm -f rickroll-custom
+
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -154,3 +198,22 @@ jobs:
       - name: Stop OVERLAY=error container
         if: always()
         run: docker rm -f rickroll-error || true
+
+      - name: Start container with OVERLAY=loading
+        run: docker run -d --name rickroll-loading -p 8080:8080 -e OVERLAY=loading rickroll:test
+
+      - name: Wait for OVERLAY=loading container to be healthy
+        run: |
+          for i in $(seq 1 30); do
+            docker exec rickroll-loading curl -fsS http://localhost:9090/healthz && exit 0
+            sleep 1
+          done
+          docker logs rickroll-loading
+          exit 1
+
+      - name: Verify loading-screen overlay autoplays muted and unmutes on click
+        run: node .github/scripts/test-autoplay.js loading
+
+      - name: Stop OVERLAY=loading container
+        if: always()
+        run: docker rm -f rickroll-loading || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,38 +45,30 @@ jobs:
           docker logs rickroll-default
           exit 1
 
-      - name: Check root redirects straight to the video
+      - name: Check index page structure
         run: |
           set -eu
-          headers=$(curl -sS -o /dev/null -D - http://localhost:8080/)
-          echo "$headers" | grep -qE '^HTTP/[0-9.]+ 302'
-          echo "$headers" | grep -qiE '^location: *http://localhost:8080/video\.mp4'
-
-      - name: Check an arbitrary path also redirects to the video
-        run: |
-          set -eu
-          headers=$(curl -sS -o /dev/null -D - http://localhost:8080/some/random/path)
-          echo "$headers" | grep -qE '^HTTP/[0-9.]+ 302'
-          echo "$headers" | grep -qiE '^location: *http://localhost:8080/video\.mp4'
-
-      - name: Check redirect doesn't leak nginx's own port behind a reverse proxy
-        run: |
-          set -eu
-          # Simulates Traefik/nginx-proxy terminating TLS on 443 and forwarding
-          # to this container's internal port - the Location header must
-          # reflect the client-facing host/scheme, not nginx's own listen port.
-          headers=$(curl -sS -o /dev/null -D - \
-            -H "Host: rickroll.example.com" \
-            -H "X-Forwarded-Proto: https" \
-            http://localhost:8080/)
-          echo "$headers" | grep -qE '^HTTP/[0-9.]+ 302'
-          echo "$headers" | grep -qiE '^location: *https://rickroll\.example\.com/video\.mp4'
+          html=$(curl -fsS http://localhost:8080/)
+          echo "$html" | grep -q '<title>Loading...</title>'
+          echo "$html" | grep -qE '<video id="video"[^>]*\bautoplay\b'
+          echo "$html" | grep -qE '<video id="video"[^>]*\bmuted\b'
+          echo "$html" | grep -q 'source src="video.mp4"'
+          echo "$html" | grep -q 'id="cookie-banner"'
+          echo "$html" | grep -q 'id="site-error"'
 
       - name: Check video file is actually served
         run: |
           headers=$(curl -sS -o /dev/null -D - http://localhost:8080/video.mp4)
           echo "$headers" | grep -qE '^HTTP/[0-9.]+ 200'
           echo "$headers" | grep -qi '^content-type: *video/mp4'
+
+      - name: Check an arbitrary path also serves the page (any URL rickrolls you)
+        run: |
+          set -eu
+          status=$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:8080/some/random/path)
+          [ "$status" = "404" ]
+          html=$(curl -sS http://localhost:8080/some/random/path)
+          echo "$html" | grep -q 'id="video"'
 
       - name: Check container runs as non-root
         run: |
@@ -114,18 +106,6 @@ jobs:
       - name: Stop custom PORT container
         run: docker rm -f rickroll-port
 
-      - name: Start container for browser test
-        run: docker run -d --name rickroll-browser -p 8080:8080 rickroll:test
-
-      - name: Wait for browser-test container to be healthy
-        run: |
-          for i in $(seq 1 30); do
-            docker exec rickroll-browser curl -fsS http://localhost:9090/healthz && exit 0
-            sleep 1
-          done
-          docker logs rickroll-browser
-          exit 1
-
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -137,9 +117,40 @@ jobs:
           npm install --no-save playwright@1
           npx playwright install --with-deps chromium
 
-      - name: Verify video autoplays with sound with zero interaction
-        run: node .github/scripts/test-autoplay.js
+      - name: Start container with OVERLAY=cookie
+        run: docker run -d --name rickroll-cookie -p 8080:8080 -e OVERLAY=cookie rickroll:test
 
-      - name: Stop browser-test container
+      - name: Wait for OVERLAY=cookie container to be healthy
+        run: |
+          for i in $(seq 1 30); do
+            docker exec rickroll-cookie curl -fsS http://localhost:9090/healthz && exit 0
+            sleep 1
+          done
+          docker logs rickroll-cookie
+          exit 1
+
+      - name: Verify cookie-banner overlay autoplays muted and unmutes on click
+        run: node .github/scripts/test-autoplay.js cookie
+
+      - name: Stop OVERLAY=cookie container
         if: always()
-        run: docker rm -f rickroll-browser || true
+        run: docker rm -f rickroll-cookie || true
+
+      - name: Start container with OVERLAY=error
+        run: docker run -d --name rickroll-error -p 8080:8080 -e OVERLAY=error rickroll:test
+
+      - name: Wait for OVERLAY=error container to be healthy
+        run: |
+          for i in $(seq 1 30); do
+            docker exec rickroll-error curl -fsS http://localhost:9090/healthz && exit 0
+            sleep 1
+          done
+          docker logs rickroll-error
+          exit 1
+
+      - name: Verify site-error overlay autoplays muted and unmutes on click
+        run: node .github/scripts/test-autoplay.js error
+
+      - name: Stop OVERLAY=error container
+        if: always()
+        run: docker rm -f rickroll-error || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,11 @@ ARG GID=101
 # Copy files into image
 COPY --link --from=video /video/video.mp4 /usr/share/nginx/html/video.mp4
 COPY --link --chmod=755 scripts/*.sh /docker-entrypoint.d/
+COPY --link --chmod=755 scripts/index/80-index.sh /docker-entrypoint.d/
+
+# Change permissions to index.html so the non-root entrypoint can
+# overwrite it at container start
+RUN chown $UID:0 /usr/share/nginx/html/index.html
 
 # Document what port is required
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 More info can be found [here](https://www.youtube.com/watch?v=dQw4w9WgXcQ).
 
-This is a self-hosted Rickroll container. Point someone at it - a link, a QR code, whatever your heart desires - and they get properly rickrolled: full video and audio of Rick Astley, autoplaying immediately with no interaction required. No plugins, no "click to unmute" button.
+This is a self-hosted Rickroll container. Point someone at it - a link, a QR code, whatever your heart desires - and they get properly rickrolled: full video and audio of Rick Astley. The video starts playing the instant the page loads; sound kicks in the moment they click anything at all, no matter what it is.
 
 Image is based on nginxinc/nginx-unprivileged, runs as a non-root user, and everything needed to serve the video is baked into the image at build time - no external dependencies at runtime.
 
@@ -28,7 +28,8 @@ Also published to GHCR if you'd rather pull from there: `ghcr.io/modem7/docker-r
 
 # How it works
 
-- Every request gets sent straight to the raw video file instead of an HTML page with a `<video>` tag embedded in it. Browsers gate unmuted autoplay on an embedded `<video>` element behind a genuine user gesture (a click/tap/keypress) - but a directly-navigated media file goes through the browser's own native media-document viewer instead, which autoplays with sound with zero interaction required. That's the whole trick, and why there's no "click to unmute" moment.
+- Every browser autoplays a muted video with zero restrictions, but every browser also actively refuses to let a page play sound without a genuine click/tap/keypress first - there's no trick or workaround for this, it's a deliberately and increasingly strictly enforced policy (the same reason YouTube and every other site with audio needs a click too). So the video autoplays muted immediately, and a decoy overlay - a fake cookie-consent banner or a fake "Something went wrong" site error, picked at random per visit (or forced via `OVERLAY`) - entices that first click, which is all it takes to unmute.
+- Only genuine clicks/taps/keypresses count for this - deliberately not mouse movement or scrolling, since browsers don't count those as real interaction either, and unmuting off one of those just gets the video paused by the browser's autoplay enforcement instead of actually unmuted.
 - The video is served through nginx's mp4 module, so seeking/scrubbing and byte-range requests work properly and responses are cached.
 - The video isn't stored in git. It's fetched from a GitHub Release asset at build time and baked into the image, so the shipped container is still fully self-contained and works offline - git just doesn't carry the binary around.
 - Built for both linux/amd64 and linux/arm64/v8.
@@ -51,6 +52,7 @@ All tags are built from the same image - only the baked-in video resolution diff
 | Variable | Description | Default |
 | :----: | --- | --- |
 | PORT | Changes the port nginx is listening on. | 8080 |
+| OVERLAY | Which decoy overlay entices the first click - `random`, `cookie`, or `error`. | random |
 
 # Configuration example
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Also published to GHCR if you'd rather pull from there: `ghcr.io/modem7/docker-r
 
 # How it works
 
-- Every browser autoplays a muted video with zero restrictions, but every browser also actively refuses to let a page play sound without a genuine click/tap/keypress first - there's no trick or workaround for this, it's a deliberately and increasingly strictly enforced policy (the same reason YouTube and every other site with audio needs a click too). So the video autoplays muted immediately, and a decoy overlay - a fake cookie-consent banner or a fake "Something went wrong" site error, picked at random per visit (or forced via `OVERLAY`) - entices that first click, which is all it takes to unmute.
+- Every browser autoplays a muted video with zero restrictions, but every browser also actively refuses to let a page play sound without a genuine click/tap/keypress first - there's no trick or workaround for this, it's a deliberately and increasingly strictly enforced policy (the same reason YouTube and every other site with audio needs a click too). So the video autoplays muted immediately, and a decoy - a fake cookie-consent banner, a fake "Something went wrong" site error, or a stuck-loading spinner - entices that first click, which is all it takes to unmute.
+- The video keeps loading/playing muted in the background the whole time so it's instantly ready, but it's completely covered by the decoy (a generic "boring website still loading" backdrop behind the cookie banner/site error, or the loading spinner's own dark screen) until the reveal - nothing looks suspicious, and nothing gives it away early.
 - Only genuine clicks/taps/keypresses count for this - deliberately not mouse movement or scrolling, since browsers don't count those as real interaction either, and unmuting off one of those just gets the video paused by the browser's autoplay enforcement instead of actually unmuted.
 - The video is served through nginx's mp4 module, so seeking/scrubbing and byte-range requests work properly and responses are cached.
 - The video isn't stored in git. It's fetched from a GitHub Release asset at build time and baked into the image, so the shipped container is still fully self-contained and works offline - git just doesn't carry the binary around.
@@ -52,7 +53,15 @@ All tags are built from the same image - only the baked-in video resolution diff
 | Variable | Description | Default |
 | :----: | --- | --- |
 | PORT | Changes the port nginx is listening on. | 8080 |
-| OVERLAY | Which decoy overlay entices the first click - `random`, `cookie`, or `error`. | random |
+| OVERLAY | Which decoy(s) can entice the first click - a comma-separated list from `cookie`, `error`, `loading`, one is picked at random per visit. Set to a single value (e.g. `cookie`) to always use just that one. | all three |
+| TITLE | Browser tab title shown once the video is revealed (after the first click/keypress/etc). | Rickroll |
+| PRE_TITLE | Browser tab title shown before the video is revealed. | Loading... |
+| HEADLINE | Optional heading rendered over the revealed video (e.g. a caption). Leave unset to omit it. | (none) |
+| HEIGHT | CSS height of the video element. | 100vh |
+| WIDTH | CSS width of the video element. | 100% |
+| OBJECT_FIT | CSS `object-fit` value for the video (`cover`, `contain`, etc). | cover |
+| LOOP | Whether the video loops (`true`/`false`). | true |
+| VIDEO_FILE | Filename of the video to serve, relative to the web root. | video.mp4 |
 
 # Configuration example
 

--- a/scripts/70-nginx.sh
+++ b/scripts/70-nginx.sh
@@ -37,32 +37,21 @@ http {
     gzip_vary on;
     gzip_http_version 1.1;
 
-    # Redirects must reflect what the client actually connected to, not
-    # nginx's own internal scheme/port - otherwise a reverse proxy that
-    # terminates TLS on 443 and forwards to some other internal port (e.g.
-    # Traefik) ends up with that internal port leaking into the Location
-    # header. Trust X-Forwarded-Proto when a proxy sets it, otherwise fall
-    # back to nginx's own scheme for direct (non-proxied) access.
-    map $http_x_forwarded_proto $redirect_scheme {
-        default $scheme;
-        https   https;
-        http    http;
-    }
-
     server {
         listen       ${PORT} default_server;
 
         root /usr/share/nginx/html;
+        index index.html;
 
         server_name _;
 
-        # Send every request straight to the raw video file instead of an
-        # HTML page embedding a <video> tag. Browsers gate unmuted autoplay
-        # on an embedded <video> element behind a genuine user gesture (a
-        # click/tap/keypress) - but a directly-navigated media file goes
-        # through the browser's native media-document viewer instead,
-        # which autoplays with sound with zero interaction required. This
-        # is why this container never has a "click to unmute" moment.
+        error_page 404 /index.html;
+
+        # nginx's own mp4 pseudo-streaming module plus native Range
+        # support already handle seeking/scrubbing efficiently via
+        # sendfile - no need to proxy back to ourselves through
+        # proxy_cache/slice, since there's no remote/slow origin here,
+        # just a local file.
         location = /video.mp4 {
             mp4;
             mp4_buffer_size     1M;
@@ -71,10 +60,6 @@ http {
             add_header Accept-Ranges bytes;
 
             aio threads=default;
-        }
-
-        location / {
-            return 302 $redirect_scheme://$http_host/video.mp4;
         }
     }
 }

--- a/scripts/70-nginx.sh
+++ b/scripts/70-nginx.sh
@@ -3,6 +3,7 @@
 set -eu
 
 PORT="${PORT:-"8080"}"
+VIDEO_FILE="${VIDEO_FILE:-"video.mp4"}"
 
 # Create nginx conf with port variable
 tee /etc/nginx/nginx.conf << 'EOF' >/dev/null
@@ -52,7 +53,7 @@ http {
         # sendfile - no need to proxy back to ourselves through
         # proxy_cache/slice, since there's no remote/slow origin here,
         # just a local file.
-        location = /video.mp4 {
+        location = /${VIDEO_FILE} {
             mp4;
             mp4_buffer_size     1M;
             mp4_max_buffer_size 20M;
@@ -85,8 +86,9 @@ server {
 }
 EOF
 
-# Apply port variable
+# Apply port and video filename variables
 sed -i s/'${PORT}'/${PORT}/g /etc/nginx/nginx.conf
+sed -i s#'${VIDEO_FILE}'#"${VIDEO_FILE}"#g /etc/nginx/nginx.conf
 
 echo ""
 echo "#####################"

--- a/scripts/index/80-index.sh
+++ b/scripts/index/80-index.sh
@@ -1,0 +1,183 @@
+#!/bin/sh
+
+set -eu
+
+OVERLAY="${OVERLAY:-"random"}"
+
+# Create index.html
+tee /usr/share/nginx/html/index.html << EOF >/dev/null
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Loading...</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            overflow: hidden;
+            background: #000;
+        }
+
+        video {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 100vh;
+            width: 100%;
+            object-fit: cover;
+        }
+
+        .overlay {
+            position: fixed;
+            left: 0;
+            right: 0;
+            z-index: 10;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }
+
+        #cookie-banner {
+            bottom: 0;
+            background: #fff;
+            color: #222;
+            padding: 16px 20px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.2);
+        }
+
+        #cookie-banner p {
+            margin: 0;
+            font-size: 14px;
+            line-height: 1.5;
+            max-width: 640px;
+        }
+
+        #cookie-banner button {
+            flex-shrink: 0;
+            background: #1a73e8;
+            color: #fff;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            font-size: 14px;
+            cursor: pointer;
+        }
+
+        #site-error {
+            top: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.5);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        #site-error .card {
+            background: #fff;
+            color: #222;
+            padding: 28px 32px;
+            border-radius: 8px;
+            text-align: center;
+            max-width: 280px;
+            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+        }
+
+        #site-error .card p.title {
+            font-size: 16px;
+            font-weight: 600;
+            margin: 0 0 6px;
+        }
+
+        #site-error .card p.code {
+            font-size: 13px;
+            color: #666;
+            margin: 0 0 16px;
+        }
+
+        #site-error button {
+            background: #f1f3f4;
+            color: #222;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            font-size: 14px;
+            cursor: pointer;
+        }
+
+        .hidden {
+            display: none !important;
+        }
+    </style>
+</head>
+<body>
+    <video id="video" autoplay muted loop playsinline>
+        <source src="video.mp4" type="video/mp4">
+        Sorry, your browser doesn't support embedded videos.
+    </video>
+
+    <div id="cookie-banner" class="overlay hidden">
+        <p>This site uses cookies to improve your experience.</p>
+        <button type="button">Accept</button>
+    </div>
+
+    <div id="site-error" class="overlay hidden">
+        <div class="card">
+            <p class="title">Something went wrong</p>
+            <p class="code">Error 500</p>
+            <button type="button">Reload</button>
+        </div>
+    </div>
+
+    <noscript>
+        <p style="position:fixed;top:0;left:0;right:0;color:#fff;background:#000;font-family:sans-serif;text-align:center;padding:8px;margin:0;">
+            <a href="video.mp4" style="color:#fff;">Click to play</a>
+        </p>
+    </noscript>
+
+    <script>
+        (function () {
+            var video = document.getElementById('video');
+            var overlays = {
+                cookie: document.getElementById('cookie-banner'),
+                error: document.getElementById('site-error')
+            };
+            var forced = "$OVERLAY";
+            var choice = (forced === 'cookie' || forced === 'error')
+                ? forced
+                : (Math.random() < 0.5 ? 'cookie' : 'error');
+            overlays[choice].classList.remove('hidden');
+
+            var events = ['click', 'keydown', 'touchstart', 'pointerdown'];
+
+            function reveal() {
+                video.muted = false;
+                video.play().catch(function () {});
+                document.title = 'Rickroll';
+                overlays.cookie.classList.add('hidden');
+                overlays.error.classList.add('hidden');
+                events.forEach(function (evt) {
+                    document.removeEventListener(evt, reveal);
+                });
+            }
+
+            events.forEach(function (evt) {
+                document.addEventListener(evt, reveal, { once: true, passive: true });
+            });
+        })();
+    </script>
+</body>
+</html>
+EOF
+
+echo ""
+echo "#####################"
+echo "Overlay: $OVERLAY"
+echo "#####################"
+echo ""
+
+exec "$@"

--- a/scripts/index/80-index.sh
+++ b/scripts/index/80-index.sh
@@ -2,7 +2,25 @@
 
 set -eu
 
+TITLE="${TITLE:-"Rickroll"}"
+PRE_TITLE="${PRE_TITLE:-"Loading..."}"
+HEADLINE="${HEADLINE:-""}"
+HEIGHT="${HEIGHT:-"100vh"}"
+WIDTH="${WIDTH:-"100%"}"
+OBJECT_FIT="${OBJECT_FIT:-"cover"}"
+LOOP="${LOOP:-"true"}"
+VIDEO_FILE="${VIDEO_FILE:-"video.mp4"}"
 OVERLAY="${OVERLAY:-"random"}"
+
+LOOP_ATTR=""
+if [ "$LOOP" = "true" ]; then
+    LOOP_ATTR="loop"
+fi
+
+HEADLINE_HTML=""
+if [ -n "$HEADLINE" ]; then
+    HEADLINE_HTML="<h1 id=\"headline\" class=\"hidden\">$HEADLINE</h1>"
+fi
 
 # Create index.html
 tee /usr/share/nginx/html/index.html << EOF >/dev/null
@@ -11,7 +29,7 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Loading...</title>
+    <title>$PRE_TITLE</title>
     <style>
         html, body {
             margin: 0;
@@ -25,29 +43,112 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
             position: fixed;
             top: 0;
             left: 0;
-            height: 100vh;
-            width: 100%;
-            object-fit: cover;
+            height: $HEIGHT;
+            width: $WIDTH;
+            object-fit: $OBJECT_FIT;
+            z-index: 0;
         }
 
-        .overlay {
+        #headline {
+            position: fixed;
+            top: 1rem;
+            left: 0;
+            width: 100%;
+            margin: 0;
+            text-align: center;
+            color: #fff;
+            font-family: sans-serif;
+            text-shadow: 0 0 6px #000;
+            z-index: 20;
+            pointer-events: none;
+        }
+
+        .hidden {
+            display: none !important;
+        }
+
+        /* Sits over the video so nothing plays visibly until the reveal -
+           the video itself keeps loading/playing muted underneath the
+           whole time, so it's instantly ready once this is hidden. */
+        .backdrop {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            z-index: 5;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }
+
+        #site-backdrop {
+            background: #18181b;
+        }
+
+        .fake-header {
+            height: 56px;
+            background: #212124;
+            border-bottom: 1px solid #3f3f46;
+            display: flex;
+            align-items: center;
+            padding: 0 20px;
+            gap: 16px;
+        }
+
+        .fake-logo {
+            width: 110px;
+            height: 20px;
+            background: #3f3f46;
+            border-radius: 4px;
+        }
+
+        .fake-nav {
+            display: flex;
+            gap: 12px;
+            margin-left: auto;
+        }
+
+        .fake-nav span {
+            width: 56px;
+            height: 12px;
+            background: #3f3f46;
+            border-radius: 6px;
+        }
+
+        .fake-content {
+            padding: 40px;
+            max-width: 720px;
+        }
+
+        .skeleton-block {
+            height: 18px;
+            background: #3f3f46;
+            border-radius: 4px;
+            margin-bottom: 14px;
+            width: 100%;
+        }
+
+        .skeleton-block.short {
+            width: 55%;
+        }
+
+        .prompt {
             position: fixed;
             left: 0;
             right: 0;
             z-index: 10;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
         }
 
         #cookie-banner {
             bottom: 0;
-            background: #fff;
-            color: #222;
+            background: #27272a;
+            color: #f4f4f5;
             padding: 16px 20px;
             display: flex;
             align-items: center;
             justify-content: space-between;
             gap: 16px;
-            box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.2);
+            border-top: 1px solid #3f3f46;
+            box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.4);
         }
 
         #cookie-banner p {
@@ -55,36 +156,39 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
             font-size: 14px;
             line-height: 1.5;
             max-width: 640px;
+            color: #d4d4d8;
         }
 
         #cookie-banner button {
             flex-shrink: 0;
-            background: #1a73e8;
-            color: #fff;
+            background: #f4f4f5;
+            color: #18181b;
             border: none;
             padding: 10px 20px;
             border-radius: 4px;
             font-size: 14px;
+            font-weight: 600;
             cursor: pointer;
         }
 
         #site-error {
             top: 0;
             bottom: 0;
-            background: rgba(0, 0, 0, 0.5);
+            background: rgba(0, 0, 0, 0.7);
             display: flex;
             align-items: center;
             justify-content: center;
         }
 
         #site-error .card {
-            background: #fff;
-            color: #222;
+            background: #27272a;
+            color: #f4f4f5;
             padding: 28px 32px;
             border-radius: 8px;
             text-align: center;
             max-width: 280px;
-            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+            border: 1px solid #3f3f46;
+            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
         }
 
         #site-error .card p.title {
@@ -95,37 +199,102 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
 
         #site-error .card p.code {
             font-size: 13px;
-            color: #666;
+            color: #a1a1aa;
             margin: 0 0 16px;
         }
 
         #site-error button {
-            background: #f1f3f4;
-            color: #222;
+            background: #f4f4f5;
+            color: #18181b;
             border: none;
             padding: 10px 20px;
             border-radius: 4px;
             font-size: 14px;
+            font-weight: 600;
             cursor: pointer;
         }
 
-        .hidden {
-            display: none !important;
+        #loading-screen {
+            background: #18181b;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        #loading-screen .wrap {
+            text-align: center;
+        }
+
+        .spinner {
+            width: 40px;
+            height: 40px;
+            margin: 0 auto 16px;
+            border: 3px solid #3f3f46;
+            border-top-color: #f4f4f5;
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+        }
+
+        @keyframes spin {
+            to {
+                transform: rotate(360deg);
+            }
+        }
+
+        #loading-screen p.status {
+            color: #a1a1aa;
+            font-size: 14px;
+            margin: 0;
+        }
+
+        #loading-fallback {
+            margin-top: 16px;
+            color: #a1a1aa;
+            font-size: 13px;
+            cursor: pointer;
+            text-decoration: underline;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+        }
+
+        #loading-fallback.shown {
+            opacity: 1;
         }
     </style>
 </head>
 <body>
-    <video id="video" autoplay muted loop playsinline>
-        <source src="video.mp4" type="video/mp4">
+    $HEADLINE_HTML
+    <video id="video" autoplay muted $LOOP_ATTR playsinline>
+        <source src="$VIDEO_FILE" type="video/mp4">
         Sorry, your browser doesn't support embedded videos.
     </video>
 
-    <div id="cookie-banner" class="overlay hidden">
+    <div id="site-backdrop" class="backdrop hidden">
+        <div class="fake-header">
+            <div class="fake-logo"></div>
+            <div class="fake-nav"><span></span><span></span><span></span></div>
+        </div>
+        <div class="fake-content">
+            <div class="skeleton-block"></div>
+            <div class="skeleton-block"></div>
+            <div class="skeleton-block short"></div>
+        </div>
+    </div>
+
+    <div id="loading-screen" class="backdrop hidden">
+        <div class="wrap">
+            <div class="spinner"></div>
+            <p class="status">Loading...</p>
+            <p id="loading-fallback">Taking longer than expected? Click to continue</p>
+        </div>
+    </div>
+
+    <div id="cookie-banner" class="prompt hidden">
         <p>This site uses cookies to improve your experience.</p>
         <button type="button">Accept</button>
     </div>
 
-    <div id="site-error" class="overlay hidden">
+    <div id="site-error" class="prompt hidden">
         <div class="card">
             <p class="title">Something went wrong</p>
             <p class="code">Error 500</p>
@@ -135,31 +304,53 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
 
     <noscript>
         <p style="position:fixed;top:0;left:0;right:0;color:#fff;background:#000;font-family:sans-serif;text-align:center;padding:8px;margin:0;">
-            <a href="video.mp4" style="color:#fff;">Click to play</a>
+            <a href="$VIDEO_FILE" style="color:#fff;">Click to play</a>
         </p>
     </noscript>
 
     <script>
         (function () {
             var video = document.getElementById('video');
-            var overlays = {
-                cookie: document.getElementById('cookie-banner'),
-                error: document.getElementById('site-error')
-            };
-            var forced = "$OVERLAY";
-            var choice = (forced === 'cookie' || forced === 'error')
-                ? forced
-                : (Math.random() < 0.5 ? 'cookie' : 'error');
-            overlays[choice].classList.remove('hidden');
+            var headline = document.getElementById('headline');
+            var title = "$TITLE";
+
+            var validTypes = ['cookie', 'error', 'loading'];
+            var configured = "$OVERLAY".split(',').map(function (s) { return s.trim(); })
+                .filter(function (s) { return validTypes.indexOf(s) !== -1; });
+            var enabled = configured.length > 0 ? configured : validTypes;
+            var choice = enabled[Math.floor(Math.random() * enabled.length)];
+
+            var siteBackdrop = document.getElementById('site-backdrop');
+            var loadingScreen = document.getElementById('loading-screen');
+            var cookieBanner = document.getElementById('cookie-banner');
+            var siteError = document.getElementById('site-error');
+
+            if (choice === 'loading') {
+                loadingScreen.classList.remove('hidden');
+                setTimeout(function () {
+                    var fallback = document.getElementById('loading-fallback');
+                    if (fallback) {
+                        fallback.classList.add('shown');
+                    }
+                }, 3000);
+            } else {
+                siteBackdrop.classList.remove('hidden');
+                (choice === 'cookie' ? cookieBanner : siteError).classList.remove('hidden');
+            }
 
             var events = ['click', 'keydown', 'touchstart', 'pointerdown'];
 
             function reveal() {
                 video.muted = false;
                 video.play().catch(function () {});
-                document.title = 'Rickroll';
-                overlays.cookie.classList.add('hidden');
-                overlays.error.classList.add('hidden');
+                document.title = title;
+                if (headline) {
+                    headline.classList.remove('hidden');
+                }
+                siteBackdrop.classList.add('hidden');
+                loadingScreen.classList.add('hidden');
+                cookieBanner.classList.add('hidden');
+                siteError.classList.add('hidden');
                 events.forEach(function (evt) {
                     document.removeEventListener(evt, reveal);
                 });
@@ -176,6 +367,9 @@ EOF
 
 echo ""
 echo "#####################"
+echo "Website height: $HEIGHT"
+echo "Website width: $WIDTH"
+echo "Video file: $VIDEO_FILE (loop=$LOOP, object-fit=$OBJECT_FIT)"
 echo "Overlay: $OVERLAY"
 echo "#####################"
 echo ""


### PR DESCRIPTION
## Summary
Real-browser testing (Vivaldi, Chrome, Edge - live site, not automated/localhost) proved the direct-video-redirect approach never actually delivered zero-interaction unmuted autoplay. Confirmed via console: `muted: false, paused: true, readyState: 4, error: null` - the exact signature of Chrome's autoplay policy blocking an unmuted-autoplay attempt for lack of a real user gesture. Every prior test passed because it ran through Playwright/automated Chromium (relaxes autoplay restrictions) and/or `localhost` (browsers treat it more permissively) - neither represents a real first-time visitor.

There's no client-side trick that gets genuine zero-interaction autoplay-with-sound in real browsers - deliberate, increasingly strict policy, same reason every site with audio needs a click.

So: video autoplays muted immediately (unrestricted), and a decoy overlay entices the first click:
- Fake cookie-consent banner ("Accept")
- Fake "Something went wrong / Error 500" site error ("Reload")

Picked at random per visit, or forced via new `OVERLAY` env var (`random`/`cookie`/`error`). Only genuine click/tap/keydown trigger the reveal - not mousemove/scroll (per the earlier Vivaldi pause bug).

## Changes
- Restores `scripts/index/80-index.sh` (deleted in #111) with the new overlay markup/JS
- Reverts `70-nginx.sh` to serving `index.html` (keeps the mp4-location cleanup - narrowed regex, no self-proxy/slice - from before)
- Dockerfile: restores the `80-index.sh` copy + index.html chown
- README: honest description of the mechanism, `OVERLAY` env var documented
- CI: replaces the redirect/reverse-proxy tests with index-page-structure checks, and the Playwright test now covers both overlay variants (muted on load, correct overlay visible, click reveals + unmutes + hides overlay)

## Test plan
- [x] Verified locally via browser preview: both overlays render correctly, `mousemove` is ignored, clicking either overlay's button unmutes + plays + hides the overlay + updates the title
- [x] Verified the new CI grep assertions against real generated HTML output
- [ ] CI (`test.yml`) passes for both overlay variants