### PR TITLE
Merge cookie banner into loading/error instead of a third option

### DIFF
--- a/.github/scripts/test-autoplay.js
+++ b/.github/scripts/test-autoplay.js
@@ -36,7 +36,7 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
     throw new Error('expected video to start autoplaying (muted) within 5s, but it never left the paused state');
   }
 
-  const initial = await page.evaluate((sel, cookieSel) => {
+  const initial = await page.evaluate(({ sel, cookieSel }) => {
     const v = document.getElementById('video');
     const overlay = document.querySelector(sel);
     const cookie = document.querySelector(cookieSel);
@@ -46,7 +46,7 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
       overlayVisible: overlay ? !overlay.classList.contains('hidden') : null,
       cookieVisible: cookie ? !cookie.classList.contains('hidden') : null
     };
-  }, overlaySelector, cookieSelector);
+  }, { sel: overlaySelector, cookieSel: cookieSelector });
 
   if (!initial.muted) {
     throw new Error(`expected video to start muted, got muted=${initial.muted}`);
@@ -73,7 +73,7 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
     throw new Error('expected video to unmute after clicking within 5s, but it is still muted');
   }
 
-  const after = await page.evaluate((sel, cookieSel) => {
+  const after = await page.evaluate(({ sel, cookieSel }) => {
     const v = document.getElementById('video');
     const overlay = document.querySelector(sel);
     const cookie = document.querySelector(cookieSel);
@@ -83,7 +83,7 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
       overlayVisible: overlay ? !overlay.classList.contains('hidden') : null,
       cookieVisible: cookie ? !cookie.classList.contains('hidden') : null
     };
-  }, overlaySelector, cookieSelector);
+  }, { sel: overlaySelector, cookieSel: cookieSelector });
 
   if (after.paused) {
     throw new Error('expected video to still be playing after unmuting');

--- a/.github/scripts/test-autoplay.js
+++ b/.github/scripts/test-autoplay.js
@@ -1,7 +1,6 @@
 const { chromium } = require('playwright');
 
 const CONFIG = {
-  cookie: { overlaySelector: '#cookie-banner', clickSelector: '#cookie-banner button' },
   error: { overlaySelector: '#site-error', clickSelector: '#site-error button' },
   loading: { overlaySelector: '#loading-screen', clickSelector: 'body' }
 };
@@ -11,6 +10,7 @@ if (!CONFIG[overlayType]) {
   throw new Error(`usage: node test-autoplay.js <${Object.keys(CONFIG).join('|')}>, got "${overlayType}"`);
 }
 const { overlaySelector, clickSelector } = CONFIG[overlayType];
+const cookieSelector = '#cookie-banner';
 
 async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {}) {
   const start = Date.now();
@@ -36,15 +36,17 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
     throw new Error('expected video to start autoplaying (muted) within 5s, but it never left the paused state');
   }
 
-  const initial = await page.evaluate((sel) => {
+  const initial = await page.evaluate((sel, cookieSel) => {
     const v = document.getElementById('video');
     const overlay = document.querySelector(sel);
+    const cookie = document.querySelector(cookieSel);
     return {
       muted: v.muted,
       title: document.title,
-      overlayVisible: overlay ? !overlay.classList.contains('hidden') : null
+      overlayVisible: overlay ? !overlay.classList.contains('hidden') : null,
+      cookieVisible: cookie ? !cookie.classList.contains('hidden') : null
     };
-  }, overlaySelector);
+  }, overlaySelector, cookieSelector);
 
   if (!initial.muted) {
     throw new Error(`expected video to start muted, got muted=${initial.muted}`);
@@ -54,6 +56,11 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
   }
   if (!initial.overlayVisible) {
     throw new Error(`expected the ${overlayType} overlay to be visible, but it wasn't`);
+  }
+  // The cookie banner is site chrome, not a page state - it should always
+  // be there regardless of which page state (loading/error) is showing.
+  if (!initial.cookieVisible) {
+    throw new Error(`expected the cookie banner to be visible alongside ${overlayType}, but it wasn't`);
   }
 
   await page.click(clickSelector);
@@ -66,15 +73,17 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
     throw new Error('expected video to unmute after clicking within 5s, but it is still muted');
   }
 
-  const after = await page.evaluate((sel) => {
+  const after = await page.evaluate((sel, cookieSel) => {
     const v = document.getElementById('video');
     const overlay = document.querySelector(sel);
+    const cookie = document.querySelector(cookieSel);
     return {
       paused: v.paused,
       title: document.title,
-      overlayVisible: overlay ? !overlay.classList.contains('hidden') : null
+      overlayVisible: overlay ? !overlay.classList.contains('hidden') : null,
+      cookieVisible: cookie ? !cookie.classList.contains('hidden') : null
     };
-  }, overlaySelector);
+  }, overlaySelector, cookieSelector);
 
   if (after.paused) {
     throw new Error('expected video to still be playing after unmuting');
@@ -85,8 +94,11 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
   if (after.overlayVisible) {
     throw new Error(`expected the ${overlayType} overlay to be hidden after clicking, but it is still visible`);
   }
+  if (after.cookieVisible) {
+    throw new Error('expected the cookie banner to be hidden after clicking, but it is still visible');
+  }
 
-  console.log(`OK: ${overlayType} overlay shown, video autoplays muted, and clicking unmutes + hides the overlay`);
+  console.log(`OK: ${overlayType} overlay + cookie banner shown, video autoplays muted, and clicking unmutes + hides both`);
   await browser.close();
 })().catch((err) => {
   console.error(err);

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,7 @@ jobs:
             -e OBJECT_FIT=contain \
             -e LOOP=false \
             -e VIDEO_FILE=custom.mp4 \
-            -e OVERLAY=cookie,loading \
+            -e OVERLAY=error,loading \
             rickroll:test
 
       - name: Wait for custom container to be healthy
@@ -145,7 +145,7 @@ jobs:
             echo "unexpected loop attribute present with LOOP=false"
             exit 1
           fi
-          echo "$html" | grep -q '"cookie,loading".split'
+          echo "$html" | grep -q '"error,loading".split'
 
       - name: Stop custom container
         run: docker rm -f rickroll-custom
@@ -161,25 +161,6 @@ jobs:
           npm install --no-save playwright@1
           npx playwright install --with-deps chromium
 
-      - name: Start container with OVERLAY=cookie
-        run: docker run -d --name rickroll-cookie -p 8080:8080 -e OVERLAY=cookie rickroll:test
-
-      - name: Wait for OVERLAY=cookie container to be healthy
-        run: |
-          for i in $(seq 1 30); do
-            docker exec rickroll-cookie curl -fsS http://localhost:9090/healthz && exit 0
-            sleep 1
-          done
-          docker logs rickroll-cookie
-          exit 1
-
-      - name: Verify cookie-banner overlay autoplays muted and unmutes on click
-        run: node .github/scripts/test-autoplay.js cookie
-
-      - name: Stop OVERLAY=cookie container
-        if: always()
-        run: docker rm -f rickroll-cookie || true
-
       - name: Start container with OVERLAY=error
         run: docker run -d --name rickroll-error -p 8080:8080 -e OVERLAY=error rickroll:test
 
@@ -192,7 +173,7 @@ jobs:
           docker logs rickroll-error
           exit 1
 
-      - name: Verify site-error overlay autoplays muted and unmutes on click
+      - name: Verify site-error + cookie banner autoplay muted and unmute on click
         run: node .github/scripts/test-autoplay.js error
 
       - name: Stop OVERLAY=error container
@@ -211,7 +192,7 @@ jobs:
           docker logs rickroll-loading
           exit 1
 
-      - name: Verify loading-screen overlay autoplays muted and unmutes on click
+      - name: Verify loading-screen + cookie banner autoplay muted and unmute on click
         run: node .github/scripts/test-autoplay.js loading
 
       - name: Stop OVERLAY=loading container

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Also published to GHCR if you'd rather pull from there: `ghcr.io/modem7/docker-r
 
 # How it works
 
-- Every browser autoplays a muted video with zero restrictions, but every browser also actively refuses to let a page play sound without a genuine click/tap/keypress first - there's no trick or workaround for this, it's a deliberately and increasingly strictly enforced policy (the same reason YouTube and every other site with audio needs a click too). So the video autoplays muted immediately, and a decoy - a fake cookie-consent banner, a fake "Something went wrong" site error, or a stuck-loading spinner - entices that first click, which is all it takes to unmute.
-- The video keeps loading/playing muted in the background the whole time so it's instantly ready, but it's completely covered by the decoy (a generic "boring website still loading" backdrop behind the cookie banner/site error, or the loading spinner's own dark screen) until the reveal - nothing looks suspicious, and nothing gives it away early.
+- Every browser autoplays a muted video with zero restrictions, but every browser also actively refuses to let a page play sound without a genuine click/tap/keypress first - there's no trick or workaround for this, it's a deliberately and increasingly strictly enforced policy (the same reason YouTube and every other site with audio needs a click too). So the video autoplays muted immediately, and a decoy page state - a stuck-loading spinner or a fake "Something went wrong" site error, picked at random - entices that first click, which is all it takes to unmute. A fake cookie-consent banner sits on top of either one, since that's realistic regardless of what the rest of the page is doing.
+- The video keeps loading/playing muted in the background the whole time so it's instantly ready, but it's completely covered by the decoy until the reveal - nothing looks suspicious, and nothing gives it away early.
 - Only genuine clicks/taps/keypresses count for this - deliberately not mouse movement or scrolling, since browsers don't count those as real interaction either, and unmuting off one of those just gets the video paused by the browser's autoplay enforcement instead of actually unmuted.
 - The video is served through nginx's mp4 module, so seeking/scrubbing and byte-range requests work properly and responses are cached.
 - The video isn't stored in git. It's fetched from a GitHub Release asset at build time and baked into the image, so the shipped container is still fully self-contained and works offline - git just doesn't carry the binary around.
@@ -53,7 +53,7 @@ All tags are built from the same image - only the baked-in video resolution diff
 | Variable | Description | Default |
 | :----: | --- | --- |
 | PORT | Changes the port nginx is listening on. | 8080 |
-| OVERLAY | Which decoy(s) can entice the first click - a comma-separated list from `cookie`, `error`, `loading`, one is picked at random per visit. Set to a single value (e.g. `cookie`) to always use just that one. | all three |
+| OVERLAY | Which page state(s) can entice the first click - a comma-separated list from `error`, `loading`, one is picked at random per visit. Set to a single value to always use just that one. A cookie-consent banner always shows on top regardless. | both |
 | TITLE | Browser tab title shown once the video is revealed (after the first click/keypress/etc). | Rickroll |
 | PRE_TITLE | Browser tab title shown before the video is revealed. | Loading... |
 | HEADLINE | Optional heading rendered over the revealed video (e.g. a caption). Leave unset to omit it. | (none) |

--- a/scripts/index/80-index.sh
+++ b/scripts/index/80-index.sh
@@ -67,79 +67,17 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
             display: none !important;
         }
 
-        /* Sits over the video so nothing plays visibly until the reveal -
-           the video itself keeps loading/playing muted underneath the
-           whole time, so it's instantly ready once this is hidden. */
-        .backdrop {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            z-index: 5;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-        }
-
-        #site-backdrop {
-            background: #18181b;
-        }
-
-        .fake-header {
-            height: 56px;
-            background: #212124;
-            border-bottom: 1px solid #3f3f46;
-            display: flex;
-            align-items: center;
-            padding: 0 20px;
-            gap: 16px;
-        }
-
-        .fake-logo {
-            width: 110px;
-            height: 20px;
-            background: #3f3f46;
-            border-radius: 4px;
-        }
-
-        .fake-nav {
-            display: flex;
-            gap: 12px;
-            margin-left: auto;
-        }
-
-        .fake-nav span {
-            width: 56px;
-            height: 12px;
-            background: #3f3f46;
-            border-radius: 6px;
-        }
-
-        .fake-content {
-            padding: 40px;
-            max-width: 720px;
-        }
-
-        .skeleton-block {
-            height: 18px;
-            background: #3f3f46;
-            border-radius: 4px;
-            margin-bottom: 14px;
-            width: 100%;
-        }
-
-        .skeleton-block.short {
-            width: 55%;
-        }
-
         .prompt {
             position: fixed;
             left: 0;
             right: 0;
             z-index: 10;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
         }
 
         #cookie-banner {
             bottom: 0;
+            z-index: 15;
             background: #27272a;
             color: #f4f4f5;
             padding: 16px 20px;
@@ -171,50 +109,75 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
             cursor: pointer;
         }
 
+        /* A genuine 500/502 error is usually rendered by a completely
+           different layer of the stack than the site itself (the load
+           balancer, the CDN, a generic web server default page) - it
+           doesn't inherit the site's own styling. A plain white
+           full-page takeover that looks nothing like the dark theme
+           everywhere else sells that far better than a dark modal
+           floating over visible page content would. */
         #site-error {
             top: 0;
             bottom: 0;
-            background: rgba(0, 0, 0, 0.7);
+            background: #ffffff;
             display: flex;
+            flex-direction: column;
             align-items: center;
             justify-content: center;
-        }
-
-        #site-error .card {
-            background: #27272a;
-            color: #f4f4f5;
-            padding: 28px 32px;
-            border-radius: 8px;
             text-align: center;
-            max-width: 280px;
-            border: 1px solid #3f3f46;
-            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
+            padding: 24px;
         }
 
-        #site-error .card p.title {
-            font-size: 16px;
+        #site-error .icon {
+            width: 56px;
+            height: 56px;
+            margin-bottom: 20px;
+        }
+
+        #site-error .code {
+            font-size: 64px;
+            font-weight: 700;
+            color: #1a1a1a;
+            line-height: 1;
+            margin: 0 0 8px;
+        }
+
+        #site-error .title {
+            font-size: 18px;
             font-weight: 600;
-            margin: 0 0 6px;
+            color: #1a1a1a;
+            margin: 0 0 12px;
         }
 
-        #site-error .card p.code {
-            font-size: 13px;
-            color: #a1a1aa;
-            margin: 0 0 16px;
+        #site-error .message {
+            font-size: 14px;
+            color: #6b6b6b;
+            max-width: 360px;
+            line-height: 1.6;
+            margin: 0 0 28px;
         }
 
         #site-error button {
-            background: #f4f4f5;
-            color: #18181b;
+            background: #1a1a1a;
+            color: #fff;
             border: none;
-            padding: 10px 20px;
+            padding: 12px 28px;
             border-radius: 4px;
             font-size: 14px;
             font-weight: 600;
             cursor: pointer;
         }
 
+        #site-error .reference {
+            margin-top: 28px;
+            font-size: 12px;
+            color: #9a9a9a;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        }
+
         #loading-screen {
+            top: 0;
+            bottom: 0;
             background: #18181b;
             display: flex;
             align-items: center;
@@ -269,19 +232,7 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
         Sorry, your browser doesn't support embedded videos.
     </video>
 
-    <div id="site-backdrop" class="backdrop hidden">
-        <div class="fake-header">
-            <div class="fake-logo"></div>
-            <div class="fake-nav"><span></span><span></span><span></span></div>
-        </div>
-        <div class="fake-content">
-            <div class="skeleton-block"></div>
-            <div class="skeleton-block"></div>
-            <div class="skeleton-block short"></div>
-        </div>
-    </div>
-
-    <div id="loading-screen" class="backdrop hidden">
+    <div id="loading-screen" class="prompt hidden">
         <div class="wrap">
             <div class="spinner"></div>
             <p class="status">Loading...</p>
@@ -289,17 +240,22 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
         </div>
     </div>
 
+    <div id="site-error" class="prompt hidden">
+        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+            <line x1="12" y1="9" x2="12" y2="13"></line>
+            <line x1="12" y1="17" x2="12.01" y2="17"></line>
+        </svg>
+        <p class="code">500</p>
+        <p class="title">Internal Server Error</p>
+        <p class="message">The server encountered an internal error and was unable to complete your request.</p>
+        <button type="button">Reload page</button>
+        <p class="reference" id="error-reference"></p>
+    </div>
+
     <div id="cookie-banner" class="prompt hidden">
         <p>This site uses cookies to improve your experience.</p>
         <button type="button">Accept</button>
-    </div>
-
-    <div id="site-error" class="prompt hidden">
-        <div class="card">
-            <p class="title">Something went wrong</p>
-            <p class="code">Error 500</p>
-            <button type="button">Reload</button>
-        </div>
     </div>
 
     <noscript>
@@ -314,6 +270,14 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
             var headline = document.getElementById('headline');
             var title = "$TITLE";
 
+            function randomHex(len) {
+                var s = '';
+                for (var i = 0; i < len; i++) {
+                    s += Math.floor(Math.random() * 16).toString(16);
+                }
+                return s.toUpperCase();
+            }
+
             // "loading" and "error" are mutually exclusive page states - a
             // page can't be both at once - so one of those two is picked
             // at random. The cookie banner isn't a page state, it's site
@@ -327,7 +291,6 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
             var enabled = configured.length > 0 ? configured : validTypes;
             var choice = enabled[Math.floor(Math.random() * enabled.length)];
 
-            var siteBackdrop = document.getElementById('site-backdrop');
             var loadingScreen = document.getElementById('loading-screen');
             var cookieBanner = document.getElementById('cookie-banner');
             var siteError = document.getElementById('site-error');
@@ -343,8 +306,11 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
                     }
                 }, 3000);
             } else {
-                siteBackdrop.classList.remove('hidden');
                 siteError.classList.remove('hidden');
+                var ref = document.getElementById('error-reference');
+                if (ref) {
+                    ref.textContent = 'Reference #' + randomHex(8);
+                }
             }
 
             var events = ['click', 'keydown', 'touchstart', 'pointerdown'];
@@ -356,7 +322,6 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
                 if (headline) {
                     headline.classList.remove('hidden');
                 }
-                siteBackdrop.classList.add('hidden');
                 loadingScreen.classList.add('hidden');
                 cookieBanner.classList.add('hidden');
                 siteError.classList.add('hidden');

--- a/scripts/index/80-index.sh
+++ b/scripts/index/80-index.sh
@@ -314,7 +314,14 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
             var headline = document.getElementById('headline');
             var title = "$TITLE";
 
-            var validTypes = ['cookie', 'error', 'loading'];
+            // "loading" and "error" are mutually exclusive page states - a
+            // page can't be both at once - so one of those two is picked
+            // at random. The cookie banner isn't a page state, it's site
+            // chrome that would realistically show up regardless of what
+            // the page underneath is doing, so it's always shown on top
+            // of whichever one gets picked, rather than being a third
+            // option that could be picked instead of them.
+            var validTypes = ['error', 'loading'];
             var configured = "$OVERLAY".split(',').map(function (s) { return s.trim(); })
                 .filter(function (s) { return validTypes.indexOf(s) !== -1; });
             var enabled = configured.length > 0 ? configured : validTypes;
@@ -324,6 +331,8 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
             var loadingScreen = document.getElementById('loading-screen');
             var cookieBanner = document.getElementById('cookie-banner');
             var siteError = document.getElementById('site-error');
+
+            cookieBanner.classList.remove('hidden');
 
             if (choice === 'loading') {
                 loadingScreen.classList.remove('hidden');
@@ -335,7 +344,7 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
                 }, 3000);
             } else {
                 siteBackdrop.classList.remove('hidden');
-                (choice === 'cookie' ? cookieBanner : siteError).classList.remove('hidden');
+                siteError.classList.remove('hidden');
             }
 
             var events = ['click', 'keydown', 'touchstart', 'pointerdown'];


### PR DESCRIPTION
## Summary
`loading` and `error` are mutually exclusive page states - a page can't be both at once - so having `cookie` as a third value in the same `OVERLAY` list let you end up with combinations that don't make sense. A cookie-consent banner isn't a page state though, it's site chrome that would realistically show up regardless of what the rest of the page is doing (loading, errored, whatever) - so it now always shows on top of whichever of `loading`/`error` gets picked, instead of competing with them for the same random slot.

- `OVERLAY` now only takes `error`/`loading` (comma-separated, or a single value to force one)
- Cookie banner always shows alongside whichever is picked
- CI updated: drops the standalone `OVERLAY=cookie` test, and the loading/error tests now also assert the cookie banner is present alongside them (and hidden again after the reveal)

## Test plan
- [x] Verified locally: cookie banner correctly appears at the bottom of both the loading spinner screen and the site-error dialog, and a click still reveals everything correctly (video unmuted, all three elements hidden, title updated)
- [ ] CI (`test.yml`) passes