### PR TITLE
Auto-build and publish on push to master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,11 @@
 ---
 
+# Bumped by video-assets.yml after a successful re-transcode, purely to
+# produce a real commit on this path - the video content itself can
+# change (re-uploaded to the same asset URLs) without any other diff
+# here for the paths filter below to detect otherwise.
+# Last video refresh: never
+
 kind: pipeline
 type: docker
 name: build-480p
@@ -49,14 +55,18 @@ steps:
   depends_on:
     - Lint Dockerfile
 
-# Auto-builds on every push to master that actually touches the shipped
-# image (Dockerfile/scripts) or a resolution's VIDEO_URL (.drone.yml
-# itself) - a README-only or CI-config-only commit won't trigger a
-# rebuild. When the video changes without any of those (a re-transcode
-# uploaded to the same asset URL), .github/workflows/video-assets.yml
-# triggers a "custom" build directly via the Drone API once it finishes,
-# since there's no git diff for a path filter to catch there. "custom" is
-# also still available for forcing a rebuild manually at any time.
+# Drone is wired up as a plain GitHub repo webhook (Settings > Webhooks),
+# so "push" here just means whatever push events that webhook forwards -
+# nothing Drone-specific to configure on the GitHub side. Auto-builds on
+# every push to master that actually touches the shipped image
+# (Dockerfile/scripts) or a resolution's VIDEO_URL (.drone.yml itself) -
+# a README-only or CI-config-only commit won't trigger a rebuild. When
+# the video changes without any of those (a re-transcode uploaded to the
+# same asset URL), .github/workflows/video-assets.yml bumps the "Last
+# video refresh" marker at the top of this file and pushes that commit,
+# which is a real touch of .drone.yml and flows through the same webhook.
+# "custom" is kept so a rebuild can still be forced manually (Drone UI or
+# API) any time, independent of either push path.
 trigger:
   branch:
     - master

--- a/.drone.yml
+++ b/.drone.yml
@@ -49,9 +49,21 @@ steps:
   depends_on:
     - Lint Dockerfile
 
+# Auto-builds on every push to master that actually touches the shipped
+# image (Dockerfile/scripts) - a README-only or CI-config-only commit
+# won't trigger a rebuild. "custom" is kept so a rebuild can still be
+# forced manually (e.g. to pick up a new video asset) without a code
+# change to hang it on.
 trigger:
+  branch:
+    - master
   event:
+    - push
     - custom
+  paths:
+    include:
+      - Dockerfile
+      - scripts/**
 
 ---
 
@@ -96,8 +108,15 @@ steps:
     - Lint Dockerfile
 
 trigger:
+  branch:
+    - master
   event:
+    - push
     - custom
+  paths:
+    include:
+      - Dockerfile
+      - scripts/**
 
 ---
 
@@ -142,8 +161,15 @@ steps:
     - Lint Dockerfile
 
 trigger:
+  branch:
+    - master
   event:
+    - push
     - custom
+  paths:
+    include:
+      - Dockerfile
+      - scripts/**
 
 ---
 
@@ -188,8 +214,15 @@ steps:
     - Lint Dockerfile
 
 trigger:
+  branch:
+    - master
   event:
+    - push
     - custom
+  paths:
+    include:
+      - Dockerfile
+      - scripts/**
 
 ---
 
@@ -235,8 +268,15 @@ steps:
   depends_on:
     - pushrm-dockerhub
 
+# No paths filter here on purpose - this pipeline doesn't build anything
+# itself, it only runs after the four build-* pipelines above (which do
+# have the filter), so it's already implicitly gated by whether those
+# ran for this particular push.
 trigger:
+  branch:
+    - master
   event:
+    - push
     - custom
   status:
     - success

--- a/.drone.yml
+++ b/.drone.yml
@@ -50,10 +50,13 @@ steps:
     - Lint Dockerfile
 
 # Auto-builds on every push to master that actually touches the shipped
-# image (Dockerfile/scripts) - a README-only or CI-config-only commit
-# won't trigger a rebuild. "custom" is kept so a rebuild can still be
-# forced manually (e.g. to pick up a new video asset) without a code
-# change to hang it on.
+# image (Dockerfile/scripts) or a resolution's VIDEO_URL (.drone.yml
+# itself) - a README-only or CI-config-only commit won't trigger a
+# rebuild. When the video changes without any of those (a re-transcode
+# uploaded to the same asset URL), .github/workflows/video-assets.yml
+# triggers a "custom" build directly via the Drone API once it finishes,
+# since there's no git diff for a path filter to catch there. "custom" is
+# also still available for forcing a rebuild manually at any time.
 trigger:
   branch:
     - master
@@ -64,6 +67,7 @@ trigger:
     include:
       - Dockerfile
       - scripts/**
+      - .drone.yml
 
 ---
 
@@ -117,6 +121,7 @@ trigger:
     include:
       - Dockerfile
       - scripts/**
+      - .drone.yml
 
 ---
 
@@ -170,6 +175,7 @@ trigger:
     include:
       - Dockerfile
       - scripts/**
+      - .drone.yml
 
 ---
 
@@ -223,6 +229,7 @@ trigger:
     include:
       - Dockerfile
       - scripts/**
+      - .drone.yml
 
 ---
 

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -7,6 +7,16 @@ on:
     paths:
       - Dockerfile
       - scripts/**
+  # Video content can change (a re-transcode uploaded to the same asset
+  # URLs) without touching git at all, so there's nothing here for the
+  # push trigger above to detect - chain off video-assets.yml finishing
+  # instead, since that's the thing that actually produces new content.
+  workflow_run:
+    workflows: ["Rebuild video release assets"]
+    types:
+      - completed
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:
@@ -15,6 +25,10 @@ permissions:
 
 jobs:
   publish:
+    # workflow_run fires regardless of whether the triggering workflow
+    # actually succeeded - skip publishing a build off a failed/partial
+    # transcode. Push and manual triggers aren't affected by this check.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,6 +1,12 @@
 name: Publish to GHCR
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - Dockerfile
+      - scripts/**
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/video-assets.yml
+++ b/.github/workflows/video-assets.yml
@@ -58,3 +58,18 @@ jobs:
           gh release upload "${{ inputs.release_tag }}" \
             "video-${{ matrix.resolution }}p.mp4" \
             --repo "${{ github.repository }}" --clobber
+
+  # Video content can change (a re-transcode uploaded to the same asset
+  # URLs) without any git diff at all, so there's nothing for Drone's own
+  # push-based trigger to detect. Kick it off directly once every
+  # resolution has actually finished uploading. Needs a DRONE_TOKEN repo
+  # secret (a personal token from your Drone account settings).
+  trigger-drone:
+    needs: transcode
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Drone build
+        run: |
+          curl -fsS -X POST \
+            -H "Authorization: Bearer ${{ secrets.DRONE_TOKEN }}" \
+            "https://drone.modem7.com/api/repos/modem7/docker-rickroll/builds?branch=master"

--- a/.github/workflows/video-assets.yml
+++ b/.github/workflows/video-assets.yml
@@ -61,15 +61,26 @@ jobs:
 
   # Video content can change (a re-transcode uploaded to the same asset
   # URLs) without any git diff at all, so there's nothing for Drone's own
-  # push-based trigger to detect. Kick it off directly once every
-  # resolution has actually finished uploading. Needs a DRONE_TOKEN repo
-  # secret (a personal token from your Drone account settings).
+  # push-triggered webhook (Settings > Webhooks in this repo) to detect.
+  # Rather than talking to Drone directly (a separate token/API to
+  # manage), just bump the marker comment at the top of .drone.yml and
+  # push it - .drone.yml is already in every pipeline's paths filter, so
+  # this is a normal push that flows through the exact same webhook the
+  # Dockerfile/scripts-triggered builds already use.
   trigger-drone:
     needs: transcode
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Drone build
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: master
+
+      - name: Bump video refresh marker and push
         run: |
-          curl -fsS -X POST \
-            -H "Authorization: Bearer ${{ secrets.DRONE_TOKEN }}" \
-            "https://drone.modem7.com/api/repos/modem7/docker-rickroll/builds?branch=master"
+          sed -i "s/# Last video refresh:.*/# Last video refresh: $(date -u +%Y-%m-%dT%H:%M:%SZ)/" .drone.yml
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .drone.yml
+          git commit -m "Bump video refresh marker to trigger a Drone rebuild"
+          git push origin master


### PR DESCRIPTION
## Summary
Both Drone and the GHCR workflow were manual-trigger-only - Drone's trigger predates this work, GHCR was built to deliberately mirror it "for consistency." That consistency is exactly what caused today's friction: a real fix merged to master, but production stayed on the old broken image until someone remembered to manually trigger both registries.

- Both now also build on **push to master**, scoped to paths that actually affect the shipped image (`Dockerfile`, `scripts/**`) - a README-only or CI-config-only commit won't trigger a full multi-platform rebuild
- Manual triggering still works too (Drone's `custom` event, GHCR's `workflow_dispatch`) - useful for forcing a rebuild without a code change to hang it on, e.g. after `video-assets.yml` produces new resolution assets

## Heads up
I can't verify the Drone side actually executes as intended without access to trigger a real push-triggered build against your instance - worth watching the first automatic run closely once this merges, particularly:
- Whether `trigger.paths.include` filtering behaves as documented
- Whether `finalize` still runs correctly given it has no paths filter of its own (it's gated by `depends_on` the four build pipelines instead, so it should only run when at least one of them does)

## Test plan
- [x] Validated YAML syntax for both files
- [x] GHCR workflow already confirmed working via manual `workflow_dispatch` trigger (unrelated verification, but confirms the job itself still runs correctly)
- [ ] First automatic push-triggered Drone build behaves as expected