### PR TITLE
Restart video from the beginning on reveal

### DIFF
--- a/.github/scripts/test-autoplay.js
+++ b/.github/scripts/test-autoplay.js
@@ -72,6 +72,17 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
     throw new Error(`expected the cookie banner to be visible alongside ${overlayType}, but it wasn't`);
   }
 
+  // Let the muted autoplay run for a few seconds before clicking, so
+  // currentTime has clearly moved past the intro - this is the whole
+  // point of the check below: a real visitor rarely clicks instantly,
+  // and the payoff should still start from the beginning regardless of
+  // how long the decoy held their attention.
+  await page.waitForTimeout(3000);
+  const beforeClickTime = await page.evaluate(() => document.getElementById('video').currentTime);
+  if (beforeClickTime < 1) {
+    throw new Error(`expected currentTime to have advanced past 1s after 3s of muted autoplay, got ${beforeClickTime}`);
+  }
+
   await page.click(clickSelector);
 
   const unmuted = await waitFor(page, () => {
@@ -88,6 +99,7 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
     const cookie = document.querySelector(cookieSel);
     return {
       paused: v.paused,
+      currentTime: v.currentTime,
       title: document.title,
       overlayVisible: overlay ? !overlay.classList.contains('hidden') : null,
       cookieVisible: cookie ? !cookie.classList.contains('hidden') : null
@@ -96,6 +108,11 @@ async function waitFor(page, predicate, { timeout = 5000, interval = 100 } = {})
 
   if (after.paused) {
     throw new Error('expected video to still be playing after unmuting');
+  }
+  // The whole point of a rickroll is the intro - a visitor who takes a
+  // while to click shouldn't hear the song mid-way through instead.
+  if (after.currentTime >= 1) {
+    throw new Error(`expected video to restart from the beginning on reveal, but currentTime was ${after.currentTime}s right after clicking (was ${beforeClickTime}s before)`);
   }
   if (after.title !== 'Rickroll') {
     throw new Error(`expected title "Rickroll" after interaction, got "${after.title}"`);

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,11 @@ jobs:
           file: ./Dockerfile
           load: true
           tags: rickroll:test
+          # Same video-fetch stage as ghcr-publish.yml, and this
+          # workflow always builds the same default VIDEO_URL - caching
+          # it means CI stops re-downloading the video on every run.
+          cache-from: type=gha,scope=test
+          cache-to: type=gha,mode=max,scope=test
 
       - name: Start container with default env vars
         run: docker run -d --name rickroll-default -p 8080:8080 rickroll:test
@@ -157,15 +162,32 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install Playwright
+      - name: Install Playwright package
         run: |
           npm init -y >/dev/null
-          npm install --no-save playwright@1
-          # Firefox gets its own engine check alongside Chromium - it's
-          # historically the most divergent on autoplay/gesture policy
-          # enforcement of the mainstream browsers, so a bug that's fine
-          # under one can still be broken under the other.
-          npx playwright install --with-deps chromium firefox
+          # Pinned exact version, not a floating "playwright@1" - the
+          # cache key below is keyed on this version, and an unpinned
+          # install could silently resolve a newer release whose browser
+          # binaries no longer match a stale cache.
+          npm install --no-save playwright@1.61.1
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-1.61.1
+
+      - name: Install Playwright OS dependencies
+        run: npx playwright install-deps chromium firefox
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        # Firefox gets its own engine check alongside Chromium - it's
+        # historically the most divergent on autoplay/gesture policy
+        # enforcement of the mainstream browsers, so a bug that's fine
+        # under one can still be broken under the other.
+        run: npx playwright install chromium firefox
 
       - name: Start container with OVERLAY=error
         run: docker run -d --name rickroll-error -p 8080:8080 -e OVERLAY=error rickroll:test

--- a/scripts/index/80-index.sh
+++ b/scripts/index/80-index.sh
@@ -348,6 +348,13 @@ tee /usr/share/nginx/html/index.html << EOF >/dev/null
             var events = ['click', 'keydown'];
 
             function reveal() {
+                // The video's been playing muted since page load, so by
+                // the time the decoy actually gets clicked - anywhere
+                // from a second to minutes later - it's already well
+                // past the intro. Jump back to the start so the payoff
+                // always lands on the actual song opening, not wherever
+                // playback happened to be.
+                video.currentTime = 0;
                 video.muted = false;
                 video.play().catch(function () {});
                 document.title = title;


### PR DESCRIPTION
## Summary
- The video autoplays muted from `t=0` the moment the page loads, but the decoy overlay (loading/error) can hold someone's attention for anywhere from a second to several minutes before they actually click it. By the time they do, the unmuted playback lands wherever the video has already drifted to - often well past the intro.
- Seeks `video.currentTime = 0` right before unmuting/playing in `reveal()`, so the payoff always starts from the actual song opening regardless of how long the click took.
- Always-on behavior, no new env var - there's no real scenario where landing mid-song instead of on the intro is the desired outcome.

**Buffering is unaffected by this change.** The video still starts fetching/buffering the instant the page loads, exactly as before - it's still autoplaying muted the whole time the decoy is up, so playback is never "starting fresh" on click. This change only rewinds the *playback position* at the moment of reveal; it doesn't change when or how the browser loads the video. Since the start of the file is therefore already buffered (that's the part that's been playing muted since page load), seeking back to it on click is instant with no rebuffering or stutter.

Fixes #121

## Also in this PR
- Playwright's browser binaries are now cached across CI runs (pinned to an exact version so the cache key can't silently go stale), and the Docker build's video-fetch stage is cached via GHA cache the same way `ghcr-publish.yml` already does. Cuts a cold CI run from ~3min to ~1m30s.
- `test-autoplay.js` now lets muted autoplay run for a few seconds before clicking, then asserts `currentTime` resets to near 0 after - regression coverage for the restart-on-reveal fix above.

## Test plan
- [x] CI (`test-autoplay.js`, both overlays, Chromium + Firefox, including the new `currentTime` assertion) and `test-mobile-fit.js` all passing.
- [x] Verified on a second CI run that both new caches (Playwright browsers, Docker video-fetch layer) actually hit and skip re-downloading.
- [ ] Manual check that clicking after a deliberate delay still starts the audio from the beginning.