### PR TITLE
ci: move Dockerfile lint from Woodpecker to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - Dockerfile
       - scripts/**
+      - .hadolint.yaml
       - .github/workflows/test.yml
       - .github/scripts/test-autoplay.js
       - .github/scripts/test-mobile-fit.js
@@ -12,13 +13,26 @@ on:
     paths:
       - Dockerfile
       - scripts/**
+      - .hadolint.yaml
       - .github/workflows/test.yml
       - .github/scripts/test-autoplay.js
       - .github/scripts/test-mobile-fit.js
   workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
+        with:
+          dockerfile: Dockerfile
+
   test:
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -19,21 +19,14 @@ when:
 # status - see https://github.com/woodpecker-ci/woodpecker/issues/4337.
 # Each build step is built from the same Dockerfile but pointed at a
 # different pre-transcoded video asset (see
-# .github/workflows/video-assets.yml). Actual functional testing (env
-# vars, autoplay/unmute behavior, container security posture) happens in
-# .github/workflows/test.yml, not here - lint + build is the only gate
-# before pushing.
+# .github/workflows/video-assets.yml). All linting and functional testing
+# (Dockerfile lint, env vars, autoplay/unmute behavior, container
+# security posture) happens in .github/workflows/test.yml, not here -
+# this pipeline only builds and pushes images.
 steps:
-  - name: lint-dockerfile
-    image: hadolint/hadolint:latest-alpine
-    commands:
-      - hadolint --version
-      - hadolint Dockerfile*
-
   - name: build-and-push-480p
     image: woodpeckerci/plugin-docker-buildx
     privileged: true
-    depends_on: [lint-dockerfile]
     settings:
       repo: ${CI_REPO}
       dockerfile: Dockerfile
@@ -54,7 +47,6 @@ steps:
   - name: build-and-push-720p
     image: woodpeckerci/plugin-docker-buildx
     privileged: true
-    depends_on: [lint-dockerfile]
     settings:
       repo: ${CI_REPO}
       dockerfile: Dockerfile
@@ -75,7 +67,6 @@ steps:
   - name: build-and-push-1080p
     image: woodpeckerci/plugin-docker-buildx
     privileged: true
-    depends_on: [lint-dockerfile]
     settings:
       repo: ${CI_REPO}
       dockerfile: Dockerfile
@@ -96,7 +87,6 @@ steps:
   - name: build-and-push-2160p
     image: woodpeckerci/plugin-docker-buildx
     privileged: true
-    depends_on: [lint-dockerfile]
     settings:
       repo: ${CI_REPO}
       dockerfile: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -fsSL "$VIDEO_URL" -o video.mp4
 # ---- Final image ----
 FROM nginxinc/nginx-unprivileged:1.31.4-alpine
 
-USER root
+USER 0
 
 ARG UID=101
 ARG GID=101
@@ -37,7 +37,7 @@ RUN chown $UID:0 /usr/share/nginx/html/index.html
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=10s \
-   cmd curl -fss http://localhost:9090/healthz || exit 1
+    CMD ["sh", "-c", "curl -fss http://localhost:9090/healthz || exit 1"]
 
 STOPSIGNAL SIGQUIT
 


### PR DESCRIPTION
## Summary
- Removes the `lint-dockerfile` step from `.woodpecker.yml` (and the `depends_on` wiring for it on all four build steps) - Woodpecker now only builds and pushes images
- Adds a `lint` job to `.github/workflows/test.yml` using `hadolint/hadolint-action`, gating the existing `test` job via `needs: lint` - all linting and functional testing now lives in GitHub Actions
- Fixes the two hadolint findings this exposes now that it's an actual gate instead of silently exiting non-zero on the Woodpecker side:
  - `USER root` -> `USER 0` (DL3066: non-numeric user-id)
  - `HEALTHCHECK CMD` shell form -> JSON array form (DL3025)

## Context
Ran hadolint locally against Dockerfile as it existed before this PR and confirmed it already exits 1 on those two findings (info + warning level) - the Woodpecker step was failing quietly. Wiring lint into the GH Actions test workflow as a hard PR gate meant those needed fixing so the new gate isn't red from day one.

## Test plan
- [x] `hadolint Dockerfile*` exits 0 after the fixes
- [x] `docker build` succeeds
- [x] Container runs as uid 101 (non-root) and `docker inspect` reports `healthy`
- [x] `curl` against the page returns 200